### PR TITLE
made a suggested change for link instructions.

### DIFF
--- a/_posts/2024-06-03-Editing-Your-Webpage-in-GitHub.md
+++ b/_posts/2024-06-03-Editing-Your-Webpage-in-GitHub.md
@@ -85,9 +85,9 @@ Embedding links into your post can allow you to easily direct your reader to oth
 
 1. Copy your desired *url* from the web. 
 
-2. Write the following markdown, titling the hyperlink in between the brackets and pasting the *url* in the following parentheses.
+2. Write the following markdown, placing the link text in between square brackets and pasting the *url* in the following parentheses.
 
-![](/assets/image/url.png) 
+`[click me](https://example.org)`
 
 And you are gonna want to sync your changes to GitHub. Select *Source Control* label your change, and hit *Commit & Push* to sync. 
 


### PR DESCRIPTION
Hi Cara, I made one small change to your markdown instructions. 

I think your links may have a problem if you surround the link with `*`. 

So instead of this `[link](*my-url*)` you should probably have `[link](my-url)`

You are definitely correct that placing a word between `*` will make it italic. But in this case, the content between the parenthesis is not "presented text" or text that should be formatted, but is the link location. So adding the `*` will actually confuse the link location.

(This is a pull request by the way. So after reviewing the change, you can accept it, and my changes will merge with your content.) 